### PR TITLE
Upgrade project to .NET 8.0 and update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ jobs:
     executor: ubuntu
     steps:
       - checkout
-      - run: ./tools/install-dotnet.sh 6.0.101
-      - run: dotnet tool install --local dotnet-reportgenerator-globaltool --version 5.1.19
+      - run: ./tools/install-dotnet.sh 8.0.100
+      - run: dotnet tool install --local dotnet-reportgenerator-globaltool --version 5.2.0
       - run: ./tools/test.sh
       - run: curl -s https://codecov.io/bash > ./codecov
       - run: chmod +x ./codecov
@@ -23,7 +23,7 @@ jobs:
     executor: ubuntu
     steps:
       - checkout
-      - run: ./tools/install-dotnet.sh 6.0.101
+      - run: ./tools/install-dotnet.sh 8.0.100
       - run: dotnet pack src/CronQuery.API/CronQuery.API.csproj -o dist
       - run: dotnet nuget push dist/CronQuery.${CIRCLE_TAG/v/}.nupkg -k $NUGET_TOKEN -s https://api.nuget.org/v3/index.json
 

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.1.19",
+      "version": "5.2.0",
       "commands": [
         "reportgenerator"
       ]

--- a/docs/www/versions.hbs
+++ b/docs/www/versions.hbs
@@ -24,7 +24,12 @@
     </thead>
     <tbody>
       <tr>
-        <td><code>v3.x</code></td>
+        <td><code>v3.1</code></td>
+        <td><code>.NET 8</code></td>
+        <td>December, 2023</td>
+      </tr>
+      <tr>
+        <td><code>v3.0</code></td>
         <td><code>.NET 6</code></td>
         <td>April, 2023</td>
       </tr>

--- a/example/Example.csproj
+++ b/example/Example.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\CronQuery.API\CronQuery.API.csproj" />

--- a/src/CronQuery.API/CronQuery.API.csproj
+++ b/src/CronQuery.API/CronQuery.API.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>CronQuery</AssemblyName>
     <AssemblyTitle>CronQuery</AssemblyTitle>
-    <AssemblyVersion>3.0.0</AssemblyVersion>
-    <Version>3.0.0</Version>
+    <AssemblyVersion>3.1.0</AssemblyVersion>
+    <Version>3.1.0</Version>
     <Authors>Marx J. Moura</Authors>
     <Owners>Marx J. Moura</Owners>
     <Copyright>Copyright (c) 2018 Marx J. Moura</Copyright>
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <PackageReference Include="System.Reactive.Core" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="System.Reactive.Core" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/src/CronQuery.Tests/CronQuery.Tests.csproj
+++ b/src/CronQuery.Tests/CronQuery.Tests.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="altcover" Version="8.6.45" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.16" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="altcover" Version="8.6.95" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
The target framework has been upgraded from .NET 6.0 to .NET 8.0 across all projects. Affected files are the csproj files for the API, tests, and example. Additionally, the versions of all package dependencies and tools have been updated to their compatible versions with .NET 8.0. This includes changes in the .config/dotnet-tools.json and .circleci/config.yml.

Also bumped package/assembly version to 3.1 (this isn't really a major change, no actual behaviours have changed, so a minor version bump seems appropriate)

Ref: #33 